### PR TITLE
fixed rendering bug when an image associated with article isn't present

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "@types/material-ui": "^0.21.12",
         "axios": "^0.26.1",
         "express": "^4.17.3",
-        "moment": "^2.29.1"
+        "moment": "^2.29.1",
+        "react-error-boundary": "^3.1.4"
       },
       "devDependencies": {
         "@types/body-parser": "^1.19.2",
@@ -2992,6 +2993,21 @@
         "react": "17.0.2"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -5849,6 +5865,14 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "scheduler": "^0.20.2"
+      }
+    },
+    "react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/material-ui": "^0.21.12",
     "axios": "^0.26.1",
     "express": "^4.17.3",
-    "moment": "^2.29.1"
+    "moment": "^2.29.1",
+    "react-error-boundary": "^3.1.4"
   }
 }

--- a/pressfeed-client/src/components/Article.tsx
+++ b/pressfeed-client/src/components/Article.tsx
@@ -1,40 +1,52 @@
-import React from 'react';
-import moment from 'moment';
-import { ArticleProps } from '../../types';
-import { Card, CardMedia, CardContent, Typography, Grid, Button } from '@mui/material'
+import React from "react";
+import moment from "moment";
+import { ArticleProps } from "../../types";
+import {
+  Card,
+  CardMedia,
+  CardContent,
+  Typography,
+  Grid,
+  Button,
+} from "@mui/material";
 
-import useStyles from '../styles/styles';
+import useStyles from "../styles/styles";
 
-
-const Article: React.FC<ArticleProps> = ({article}:any, {articleKey}) => {
-  const articleDate = moment(article.published_date).format('MM/DD/YYYY');
+const Article: React.FC<ArticleProps> = ({ article }: any, { articleKey }) => {
+  const articleDate = moment(article.published_date).format("MM/DD/YYYY");
   const classes = useStyles();
-
   const byline = article.byline.length > 0 ? "| " + article.byline : "";
 
+  const photo: string = article.multimedia !== null ? article.multimedia[0].url : "https://demofree.sirv.com/nope-not-here.jpg";
+  const caption: string = article.multimedia !== null ? article.multimedia[0].caption : "cannot load caption";
+
   return (
-    <Grid item>
-      <Card sx={{ maxWidth: 325 }} variant="outlined">
-        <Typography variant='h5' className={classes.title}>
+    <Grid item xs="auto">
+      <Card sx={{ maxWidth: 300 }} variant="outlined">
+        <Typography variant="h5" className={classes.title}>
           {article.title}
         </Typography>
         <CardMedia
-        component="img"
-        height="140"
-        image={article.multimedia[0].url}
-        alt={article.multimedia[0].caption}
-        className={classes.cardMedia}
+          component="img"
+          height="140"
+          image={photo}
+          alt={caption}
+          className={classes.cardMedia}
         />
-        <p className={classes.articleDate}>{articleDate} {byline}</p>
+        <p className={classes.articleDate}>
+          {articleDate} {byline}
+        </p>
         <CardContent>
-          <Typography gutterBottom variant='h6'>
+          <Typography gutterBottom variant="h6">
             {article.abstract}
           </Typography>
-          <Button variant="contained" href={article.short_url} target="_blank">Read more...</Button>
+          <Button variant="contained" href={article.short_url} target="_blank">
+            Read more...
+          </Button>
         </CardContent>
       </Card>
     </Grid>
-  )
+  );
 };
 
 export default Article;

--- a/pressfeed-client/src/components/Feed.tsx
+++ b/pressfeed-client/src/components/Feed.tsx
@@ -13,7 +13,7 @@ const Feed: React.FC<Props> = ({articles}) => {
   if (articles !== undefined) {
     return (
       <Container maxWidth="md" className={classes.container}>
-        <Grid container spacing={6}>
+        <Grid container spacing={6} columns={3}>
         {articles.map((article) => {
           articleKey ++;
           return (


### PR DESCRIPTION
App was failing to render properly in the case that an article didn't have an image associated (cannot read properties of null) - now images and image captions have default error fallbacks.