### PR TITLE
radio buttons now correctly rendering favorites

### DIFF
--- a/pressfeed-client/src/App.tsx
+++ b/pressfeed-client/src/App.tsx
@@ -3,7 +3,7 @@ import Feed from "./components/Feed";
 import Appbar from "./components/Appbar";
 import Menu from "./components/Menu";
 import RadioButtons from "./components/RadioButtons";
-import {refreshFeed, addToDatabase, removeFromDatabase} from "./api-routes/routes";
+import {refreshFeed, addToDatabase, removeFromDatabase, getFavorites} from "./api-routes/routes";
 import { CssBaseline } from "@mui/material";
 import "./styles/App.css";
 
@@ -11,13 +11,22 @@ const App: React.FC = () => {
   const [articles, setArticles] = useState<Array<any>>([]);
   const [filteredArticles, setFilteredArticles] = useState<Array<any>>([]);
   const [searchTerm, setSearchTerm] = useState("");
+  const [favorites, setFavorites] = useState<Array<any>>([]);
+  const [display, setDisplay] = useState<Array<any>>([]);
 
   useEffect(() => {
     const getData = async () => {
       const data = await refreshFeed("Home");
-      setArticles(data.data);
+      await setArticles(data.data);
+      setDisplay(data.data);
     };
+
+    const updateFavorites = async () => {
+      const newFavorites = await getFavorites();
+      setFavorites(newFavorites);
+    }
     getData();
+    updateFavorites();
   }, []);
 
   const newMenuProps = {
@@ -43,6 +52,15 @@ const App: React.FC = () => {
     },
   };
 
+  const radioButtonFunctions = {
+    handleClickFeed: () => {
+      setDisplay(articles);
+    },
+    handleClickFavorites: () => {
+      setDisplay(favorites);
+    }
+  }
+
   const articleFunctions = {
     addToFavorites: (id: string) => {
       addToDatabase(articles.filter((article) => article.short_url === id)[0]);
@@ -52,14 +70,17 @@ const App: React.FC = () => {
     }
   }
 
+  console.log(articles);
+  console.log(favorites);
+
   return (
     <div>
       <CssBaseline />
       <Appbar {...feedProps} />
       <main>
         <Menu {...newMenuProps} />
-        <RadioButtons/>
-        <Feed articleFunctions={articleFunctions} articles={searchTerm.length >= 3 ? filteredArticles : articles}/>
+        <RadioButtons radioButtonFunctions={radioButtonFunctions}/>
+        <Feed articleFunctions={articleFunctions} articles={searchTerm.length >= 3 ? filteredArticles : display}/>
       </main>
     </div>
   );

--- a/pressfeed-client/src/api-routes/routes.ts
+++ b/pressfeed-client/src/api-routes/routes.ts
@@ -16,4 +16,9 @@ export const removeFromDatabase = async (article: object) => {
   return response;
 }
 
+export const getFavorites = async () => {
+  const response = await axios.get(`http://localhost:8000/favorites`);
+  return response.data;
+}
+
 

--- a/pressfeed-client/src/components/RadioButtons.tsx
+++ b/pressfeed-client/src/components/RadioButtons.tsx
@@ -1,6 +1,7 @@
 import { Radio, RadioGroup, FormControl, FormControlLabel } from "@mui/material";
+import { RadioButtonProps } from "../../types";
 
-const RadioButtons: React.FC = () => {
+const RadioButtons: React.FC<RadioButtonProps> = ({radioButtonFunctions}: any) => {
 
   return (
     <FormControl style={{marginLeft: "19vw"}}>
@@ -10,8 +11,8 @@ const RadioButtons: React.FC = () => {
         name="position"
         defaultValue="feed"
       >
-        <FormControlLabel value="feed" control={<Radio/>} label="Feed" labelPlacement="bottom"/>
-        <FormControlLabel value="favorites" control={<Radio/>} label="Favorites" labelPlacement="bottom"/>
+        <FormControlLabel value="feed" control={<Radio/>} label="Feed" labelPlacement="bottom" onClick={() => {radioButtonFunctions.handleClickFeed()}}/>
+        <FormControlLabel value="favorites" control={<Radio/>} label="Favorites" labelPlacement="bottom" onClick={() => {radioButtonFunctions.handleClickFavorites()}}/>
       </RadioGroup>
 
     </FormControl>

--- a/pressfeed-client/types.ts
+++ b/pressfeed-client/types.ts
@@ -17,4 +17,8 @@ export interface AppbarProps {
   filterFeed: any
 }
 
+export interface RadioButtonProps {
+  radioButtonFunctions: object
+}
+
 

--- a/pressfeed-server/models/handleDatabase.ts
+++ b/pressfeed-server/models/handleDatabase.ts
@@ -2,18 +2,22 @@ import client from '../../database';
 
 const addToDatabase = (article: any) => {
   client.query(`INSERT INTO favorites (title, byline, abstract, shorturl, imgurl, caption, publishdate) VALUES ('${article.title}', '${article.byline}', '${article.abstract}', '${article.short_url}', '${article.multimedia[0].url}', '${article.multimedia[0].caption}', '${article.published_date}')`)
-    .then(() => {
-      console.log('Article added to favorites!')
-    })
-    .catch((err: Error) => { console.error(err); });
+    .then(() => console.log('Article added to favorites!'))
+    .catch((err: Error) => console.error(err));
 }
 
 const removeFromDatabase = (url: string) => {
   client.query(`DELETE FROM favorites WHERE shorturl='${url}'`)
-    .then(() => {
-      console.log('Article deleted from favorites!');
-    })
-    .catch((err: Error) => { console.error(err); });
+    .then(() => console.log('Article deleted from favorites!'))
+    .catch((err: Error) =>  console.error(err));
 }
 
-module.exports = { addToDatabase, removeFromDatabase }
+const getFavorites = async () => {
+  const data = await client.query(`SELECT * FROM favorites`)
+                        .then ((data: object) => data)
+                        .catch((err: Error) => console.error(err));
+
+  return data;
+}
+
+module.exports = { addToDatabase, removeFromDatabase, getFavorites }

--- a/pressfeed-server/src/index.ts
+++ b/pressfeed-server/src/index.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 const { getStories } = require('../models/getStories');
-const { addToDatabase, removeFromDatabase } = require('../models/handleDatabase');
+const { addToDatabase, removeFromDatabase, getFavorites } = require('../models/handleDatabase');
 const {NYT_API_KEY} = require('../../config.ts');
 const app = express();
 const PORT: number = 8000;
@@ -20,6 +20,26 @@ app.get('/refreshfeed', async (req, res) => {
   } else {
     res.status(400).send();
   }
+});
+
+app.get('/favorites', async (req, res) => {
+  const responseData = await getFavorites();
+
+  const responseObject = responseData.rows.map((article: Array<any>) => {
+    return (
+      {
+        "id": article[0],
+        "title": article[1],
+        "byline": article[2],
+        "abstract": article[3],
+        "shorturl": article[4],
+        "multimedia": [{"url": article[5], "caption": article[6]}],
+        "publishdate": article[7]
+      }
+    )
+  });
+
+  res.status(200).send(responseObject);
 });
 
 app.post('/add', (req, res) => {


### PR DESCRIPTION
When the app initializes, favorites are pulled from database. The App's newsfeed is, by default, rendered with all the articles pulled from a NY Times API according to the user's selected category. When "Favorites" radio button is selected, only articles in the user's favorites are rendered - when the "Feed" button is selected the feed returns to the normal selection of articles pulled from NY Times API. 